### PR TITLE
Include current-system page for get replacement text on poultry-type

### DIFF
--- a/app/helpers/handlers.js
+++ b/app/helpers/handlers.js
@@ -67,6 +67,8 @@ const insertYarValue = (field, url, request) => {
       case 'easy-grip-perches':
         return getReplacementText(request, additionalYarKeyName, 'poultry-type', 'poultry-type-A1', 'an aviary\'s', 'a multi-tier system\'s')
       case 'renewable-energy':
+      case 'current-system':
+        return getReplacementText(request, additionalYarKeyName, 'poultry-type', 'poultry-type-A1', 'hen', 'pullet')
       case 'veranda-features':
         return field.includes('{{_poultryType_}}') ? getReplacementText(request, additionalYarKeyName, 'poultry-type', 'poultry-type-A1', 'hen', 'pullet') : 
           getReplacementText(request, 'poultryType', 'poultry-type', 'poultry-type-A1', '30', '10')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-laying-hens-web",
-  "version": "1.105.3",
+  "version": "1.105.4",
   "description": "Web frontend for laying hens",
   "homepage": "https://github.com/DEFRA/ffc-grants-laying-hens-web",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/current-system.test.js
+++ b/test/integration/narrow/routes/current-system.test.js
@@ -2,21 +2,22 @@ const { commonFunctionsMock } = require('../../../session-mock')
 const { crumbToken } = require('./test-helper')
 
 describe('Page: /current-system', () => {
-  let varList = {
-    poultryType: 'hen',
-  }
-
+  let varList = {}
   let valList = {}
+  let utilsList = {}
   
-  commonFunctionsMock(varList, undefined, {}, valList)
+  commonFunctionsMock(varList, undefined, utilsList, valList)
 
   it('page loads successfully, with all the options', async () => {
+    varList.poultryType = 'Hens'
+    utilsList['poultry-type-A1'] = 'Hens'
     const options = {
       method: 'GET',
       url: `${global.__URLPREFIX__}/current-system`
     }
 
     const response = await global.__SERVER__.inject(options)
+
     expect(response.statusCode).toBe(200)
     expect(response.payload).toContain('What type of hen housing system do you currently use in the building?')
     expect(response.payload).toContain('Colony cage')
@@ -25,9 +26,13 @@ describe('Page: /current-system', () => {
     expect(response.payload).toContain('Free range')
     expect(response.payload).toContain('Organic')
     expect(response.payload).toContain('None of the above')
+    delete varList.poultryType
+    delete utilsList['poultry-type-A1']
   })
 
   it('no option selected -> show error message', async () => {
+    varList.poultryType = 'Hens'
+    utilsList['poultry-type-A1'] = 'Hens'
     valList['NOT_EMPTY'] = {
       error: 'Select what type of hen housing system you currently use',
       return: false
@@ -43,6 +48,9 @@ describe('Page: /current-system', () => {
     const postResponse = await global.__SERVER__.inject(postOptions)
     expect(postResponse.statusCode).toBe(200)
     expect(postResponse.payload).toContain('Select what type of hen housing system you currently use')
+    delete varList.poultryType
+    delete utilsList['poultry-type-A1']
+    delete valList['NOT_EMPTY']
   })
 
   it('user selects eligible option(Barn) -> store user response and redirect to /current-multi-tier-system', async () => {

--- a/test/integration/narrow/routes/easy-grip-perches.test.js
+++ b/test/integration/narrow/routes/easy-grip-perches.test.js
@@ -4,17 +4,14 @@ const { crumbToken } = require('./test-helper')
 describe('Page: /easy-grip-perches', () => {
   const varList = {}
   const valList = {}
+  const utilsList = { }
   const NON_HENS = 'Pullets'
 
-  const utilsList = {
-    'poultry-type-A1': 'Hens',
-    'poultry-type-A2': 'Pullets'
-  }
-  
   commonFunctionsMock(varList, undefined, utilsList, valList)
 
   it('page loads successfully, with all the options - hens', async () => {
     varList.poultryType = 'Hens'
+    utilsList['poultry-type-A1'] = 'Hens'
     const options = {
       method: 'GET',
       url: `${global.__URLPREFIX__}/easy-grip-perches`
@@ -27,10 +24,12 @@ describe('Page: /easy-grip-perches', () => {
     expect(response.payload).toContain('Yes')
     expect(response.payload).toContain('No')
     delete varList.poultryType
+    delete utilsList['poultry-type-A1']
   })
 
   it('page loads successfully, with all the options - pullets', async () => {
     varList.poultryType = NON_HENS
+    utilsList['poultry-type-A2'] = NON_HENS
     const options = {
       method: 'GET',
       url: `${global.__URLPREFIX__}/easy-grip-perches`
@@ -43,6 +42,7 @@ describe('Page: /easy-grip-perches', () => {
     expect(response.payload).toContain('Yes')
     expect(response.payload).toContain('No')
     delete varList.poultryType
+    delete utilsList['poultry-type-A2']
   })
 
   it('no option selected -> show error message - hens', async () => {
@@ -98,6 +98,5 @@ describe('Page: /easy-grip-perches', () => {
     expect(response.statusCode).toBe(200)
     expect(response.payload).toContain('<a href=\"dark-brooders\" class=\"govuk-back-link\">Back</a>')
   })
-
 
 })


### PR DESCRIPTION
This change fixes incorrect title and validation error message by changing:
Hens -> hen
Pullets -> pullet

Title example before:
![image (2)](https://github.com/user-attachments/assets/7f217138-ae78-4745-858a-5ae95d0254e6)

Title example after:
![image (1)](https://github.com/user-attachments/assets/8cddcc6e-c122-4d12-8306-bbedc06ed8bf)

Validation example before:
![Screenshot 2024-08-05 at 10 42 09](https://github.com/user-attachments/assets/b6133208-653f-453e-aa20-1bffb3acefa2)

Validation example after:
![Screenshot 2024-08-05 at 10 40 08](https://github.com/user-attachments/assets/5af1b864-9c3c-4868-b5fd-6f3825b2f274)
